### PR TITLE
Handle corner case in ResourceConfig.get

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -478,7 +478,7 @@ func (c *ResourceConfig) get(
 				}
 				current = cv.Index(int(i)).Interface()
 			}
-		case reflect.String:
+		default:
 			// This happens when map keys contain "." and have a common
 			// prefix so were split as path components above.
 			actualKey := strings.Join(parts[i-1:], ".")
@@ -488,8 +488,6 @@ func (c *ResourceConfig) get(
 			}
 
 			return nil, false
-		default:
-			panic(fmt.Sprintf("Unknown kind: %s", cv.Kind()))
 		}
 	}
 

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -236,6 +236,21 @@ func TestResourceConfigGet(t *testing.T) {
 			Key:   "mapname.0.listkey.0.key",
 			Value: 3,
 		},
+		{
+			Config: cty.ObjectVal(map[string]cty.Value{
+				"mapname": cty.MapVal(map[string]cty.Value{
+					"key:name":        cty.NumberIntVal(1),
+					"key:name.suffix": cty.NumberIntVal(2),
+				}),
+			}),
+			Schema: &configschema.Block{
+				Attributes: map[string]*configschema.Attribute{
+					"mapname": {Type: cty.Map(cty.Number), Optional: true},
+				},
+			},
+			Key:   "mapname.key:name.suffix",
+			Value: 2,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Backport https://github.com/hashicorp/terraform-plugin-sdk/pull/659 in v1

Why this backport ?
Because the datadog provider is not ready to use terraform-plugin-sdk v2 currently

This fix allows to bypass a "panic" during "terraform plan"